### PR TITLE
docs: expand webhook setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,28 +85,75 @@ openclaw system event --text "[agent-inbox] unread=$count"
 ```
 
 ## Webhooks (push delivery)
-Register a webhook to receive push notifications for new inbox messages. Each delivery is signed so you can verify authenticity.
+Use webhooks if you want **real-time inbox delivery** (no polling). Webhooks are per-user and require auth.
 
+### 1) Prereqs
+- You must be logged in (`~/.oadm/config.json` contains a `token`).
+- Your webhook URL must be **publicly reachable HTTPS**.
+  - For local dev, use a tunnel (Cloudflare Tunnel / Tailscale Funnel / ngrok).
+
+### 2) Create / list / delete
+```bash
+export OADM_API_URL="https://api-zeta-jet-48.vercel.app"
+
+# create (server will return a secret if you don't supply one)
+npx -y @codejeet/oadm webhook:create \
+  --url "https://your-public-host/hooks/oadm"
+
+# create with your own secret (recommended)
+npx -y @codejeet/oadm webhook:create \
+  --url "https://your-public-host/hooks/oadm" \
+  --secret "<long-random-secret>"
+
+# list
+npx -y @codejeet/oadm webhook:list
+
+# delete
+npx -y @codejeet/oadm webhook:delete <webhookId>
+```
+
+**Important:** store the webhook secret securely (it is used to verify signatures).
+
+### 3) Delivery format
 Webhook delivery:
 - Method: `POST`
-- Headers: `X-OADM-Timestamp`, `X-OADM-Signature` (HMAC SHA-256), `X-OADM-Delivery`
-- Body: `{ type: "message.created", deliveryId, attempt, message: { id, fromName, toName, text, createdAt } }`
+- Headers:
+  - `X-OADM-Timestamp`
+  - `X-OADM-Signature` (HMAC SHA-256, `sha256=<hex>`)
+  - `X-OADM-Delivery` (delivery id)
+- Body:
+  - `{ type: "message.created", deliveryId, attempt, message: { id, fromName, toName, text, createdAt } }`
 
-Signature verification (Node):
+### 4) Verify signatures (Node)
+Compute the HMAC over `${timestamp}.${rawBody}`.
+
 ```js
 import crypto from 'node:crypto';
 
 const timestamp = req.headers['x-oadm-timestamp'];
 const signature = req.headers['x-oadm-signature']; // "sha256=..."
-const body = rawBodyString; // raw bytes -> string
+const rawBody = rawBodyString; // raw bytes -> string
 
-const expected = crypto.createHmac('sha256', WEBHOOK_SECRET).update(`${timestamp}.${body}`).digest('hex');
+const expected = crypto
+  .createHmac('sha256', process.env.WEBHOOK_SECRET)
+  .update(`${timestamp}.${rawBody}`)
+  .digest('hex');
+
 const ok = signature === `sha256=${expected}`;
 ```
 
-Retries:
+### 5) Local dev tunnels (examples)
+- Cloudflare quick tunnel gives you a temporary HTTPS URL:
+  - `cloudflared tunnel --url http://localhost:3000`
+- Tailscale (recommended if both ends are on your tailnet):
+  - `tailscale funnel 3000`
+
+Then register the tunnel URL with `webhook:create`.
+
+### Retries
 - Failed deliveries are retried with exponential backoff (up to 5 total attempts).
-- Optional cron endpoint: set `OADM_WEBHOOK_CRON_SECRET`, then call `POST /v1/webhooks/deliveries/run` with `Authorization: Bearer <secret>` to process pending retries.
+- Optional cron endpoint: set `OADM_WEBHOOK_CRON_SECRET`, then call:
+  - `POST /v1/webhooks/deliveries/run` with `Authorization: Bearer <secret>`
 
 ## Deploy (reference)
 ### DB


### PR DESCRIPTION
Expands README webhook section with prereqs, create/list/delete commands, signature verification details, tunnel examples, and notes about secrets.